### PR TITLE
Fixes n+1's and adds listing_order sort index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,8 @@ end
 group :development do
   # gem 'test-unit', '~> 3.0'
   gem 'rerun'
+  gem 'bullet'
+  gem 'pry-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,9 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       sass (>= 3.4.19)
     builder (3.2.3)
+    bullet (5.9.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     carrierwave (0.11.2)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -312,6 +315,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     rack (1.6.11)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -508,6 +513,7 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
+    uniform_notifier (1.12.1)
     user_agent_parser (2.3.0)
     vcr (4.0.0)
     vegas (0.1.11)
@@ -543,6 +549,7 @@ DEPENDENCIES
   backbone-on-rails (~> 0.9.10.0)
   bcrypt (~> 3.1.7)
   bootstrap (~> 4.0.0.alpha3)
+  bullet
   bundler (>= 1.8.4)
   carrierwave
   carrierwave_backgrounder
@@ -593,6 +600,7 @@ DEPENDENCIES
   pg
   pg_search
   premailer-rails
+  pry-rails
   rack-contrib
   rack-mini-profiler
   rack-throttle

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -64,7 +64,11 @@ class Bike < ActiveRecord::Base
 
   attr_writer :phone, :user_name # reading is managed by a method
 
-  default_scope { where(example: false).where(hidden: false).order('listing_order desc') }
+  default_scope { 
+    includes(:tertiary_frame_color, :secondary_frame_color, :primary_frame_color, :current_stolen_record, :cycle_type)
+    .where(example: false, hidden: false)
+    .order('listing_order desc') 
+  }
   scope :stolen, -> { where(stolen: true) }
   scope :non_stolen, -> { where(stolen: false) }
   scope :with_serial, -> { where('serial_number != ?', 'absent') }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -217,7 +217,9 @@ class User < ActiveRecord::Base
   end
 
   def bikes(user_hidden=true)
-    Bike.unscoped.where(id: bike_ids(user_hidden))
+    Bike.unscoped
+    .includes(:tertiary_frame_color, :secondary_frame_color, :primary_frame_color, :current_stolen_record, :cycle_type)
+    .where(id: bike_ids(user_hidden))
   end
 
   def rough_approx_bikes # Rough fix for users with large numbers of bikes
@@ -225,7 +227,7 @@ class User < ActiveRecord::Base
   end
 
   def bike_ids(user_hidden=true)
-    ows = ownerships.where(example: false).where(current: true)
+    ows = ownerships.includes(:bike).where(example: false, current: true)
     if user_hidden
       ows = ows.map{ |o| o.bike_id if o.user_hidden || o.bike }
     else

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,13 +46,21 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   config.lograge.enabled = true
-  config.log_level = :info
+  config.log_level = :debug
   config.lograge.formatter = Lograge::Formatters::Logstash.new # Use logstash format
   config.lograge.custom_options = lambda do |event|
     {
       remote_ip: event.payload[:ip],
       params: event.payload[:params].except('controller', 'action', 'format', 'id')
     }
+  end
+
+  # Bullet for n+1's
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
   end
 
   # Raises error for missing translations

--- a/db/migrate/20190206044915_add_listing_order_index_to_bikes.rb
+++ b/db/migrate/20190206044915_add_listing_order_index_to_bikes.rb
@@ -1,0 +1,7 @@
+class AddListingOrderIndexToBikes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :bikes, :listing_order, order: { listing_order: :desc }, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3078,6 +3078,13 @@ CREATE INDEX index_bikes_on_cycle_type_id ON public.bikes USING btree (cycle_typ
 
 
 --
+-- Name: index_bikes_on_listing_order; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_on_listing_order ON public.bikes USING btree (listing_order DESC);
+
+
+--
 -- Name: index_bikes_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4098,4 +4105,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190110210704');
 INSERT INTO schema_migrations (version) VALUES ('20190201193608');
 
 INSERT INTO schema_migrations (version) VALUES ('20190201214042');
+
+INSERT INTO schema_migrations (version) VALUES ('20190206044915');
 


### PR DESCRIPTION
* Increases log verbosity in `development` to get some visibility on AR query usage/cost
* Fixes n+1's from `welcome#user_home` - just needed to eager load `bike` on `ownerships`
* Fixes similar n+1's occurring from `bikes#index`
* Adds `listing_order` sort index to improve the query planer for a widely used query in `bikes#index`.  There's a small improvement with this index instead of a seq scan which halves the # of rows:

```
Bike.search({:stolenness=>"non"}).explain

Before w/ no index:
-------------------------------------------------------------------
 Sort  (cost=22045.56..22067.49 rows=8770 width=5591)
   Sort Key: listing_order DESC
   ->  Seq Scan on bikes  (cost=0.00..425.70 rows=8770 width=5591)
         Filter: ((NOT example) AND (NOT hidden) AND (NOT stolen))
(4 rows)

After:
-------------------------------------------------------------------
Index Scan using index_bikes_on_listing_order on bikes  (cost=0.29..576.84 rows=8770 width=5591)
   Filter: ((NOT example) AND (NOT hidden) AND (NOT stolen))
(2 rows)

Note:  If possible it would be nice to test this locally against something similar to whats on production
```

